### PR TITLE
removed comma that created an error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,7 @@ I wanted to have a graphical visualization of the load of most physical devices.
 
 Dependencies (Python 3):
 ```
-pip install pyqtgraph, pyqt5
+pip install pyqtgraph pyqt5
 ```
 clone the project and cd into src/. Then
 ```


### PR DESCRIPTION
If I copy pasted this, i got an error:
`ERROR: Invalid requirement: 'pyqtgraph,'`
I removed the comma in the readme so the error disappears