### PR TITLE
More sbin paths for different distributions

### DIFF
--- a/src/sysmon/sysmon.py
+++ b/src/sysmon/sysmon.py
@@ -599,7 +599,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
 
 def main():
-    os.environ['PATH'] = '/sbin:' + os.environ.get('PATH')
+    os.environ['PATH'] = '/sbin:/usr/local/sbin:/usr/sbin:' + os.environ.get('PATH')
     app = QtWidgets.QApplication(sys.argv)
     main = MainWindow()
     main.show()


### PR DESCRIPTION
Different distros put `iwconfig` in different places. 

openSUSE puts iwconfig in `/usr/sbin/iwconfig` and Debian puts it in `/sbin/iwconfig`.  I didn't notice this issue because I only tested my patch on Debian.

This should fix @hamadmarri's issue on his openSUSE machine.